### PR TITLE
tidy cookie code away and sort out resources navigation in

### DIFF
--- a/_includes/_cookies.html
+++ b/_includes/_cookies.html
@@ -1,0 +1,92 @@
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <h2 class="govuk-heading-l">Cookies</h2>
+        <p class="govuk-body">The UK Cross Government Software Community  site puts small files (known as 'cookies') onto your computer to collect information about how you browse the site.</p>
+        <p class="govuk-body">Cookies are used to:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>measure how you use the website so it can be updated and improved based on your needs</li>
+       </ul>
+        <div class="govuk-inset-text">
+          <p class="capitalize">The UK Cross Government Software Community  site cookies aren’t used to identify you personally.</p>
+        </div>
+        <p class="govuk-body">You’ll normally see a message on the site before we store a cookie on your computer.</p>
+        <p class="govuk-body">Find out more about 
+            <a target='_blank' href="http://www.aboutcookies.org/" class="govuk-link">how to manage cookies.</a>
+        </p>
+        <h2 class="govuk-heading-l">How cookies are used on the UK Cross Government Software Community  site</h2>
+        <p class="govuk-body">There are a number of different types of cookie used in the Cross Government Software Community  site which allow the system to work securely and consistently.
+        These are:</p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>Google Analytics cookies</li>
+            <li class="capitalize">The UK Cross Government Software Community site cookies</li>
+            <li>Third-party cookies</li>
+        </ul>
+        <h3 class="govuk-heading-m">Google Analytics cookies</h3>
+        <p class="govuk-body">We use Google Analytics software to collect information about how you use the Cross Government Software Community  site. We do this to help make sure the site is meeting the needs of its users and to help us make improvements.</p>
+        <p class="govuk-body">Google Analytics stores information about:</p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>the pages you visit on the Cross Government Software Community  site</li>
+            <li>how long you spend on each page</li>
+            <li>how you got to the site</li>
+            <li>what you click on while you're visiting the site</li>
+            <li>Google does not collect or store your personal information, for example your name or address, so this information can't be used to identify who you are. We don't allow Google to use or share our analytics data.</li>
+        </ul>
+        <p class="govuk-body">Google Analytics sets the following cookies:</p>
+        <table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Name</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-two-thirds">Purpose</th>
+      <th scope="col" class="govuk-table__header">Expiry</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">_ga</th>
+          <td class="govuk-table__cell">This helps us count how many people visit the service by tracking if the user has visited before</td>
+          <td class="govuk-table__cell">2 years</td> 
+        </tr>
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">_ga_XXXXX</th>
+          <td class="govuk-table__cell">Used to distinguish between users of the service</td>
+          <td class="govuk-table__cell">2 years</td>
+        </tr>
+  </tbody>
+</table>
+    </div>    
+  </div>
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <h3 class="govuk-heading-m capitalize">The UK Cross Government Software Community  site application cookies</h3>
+        <p class="govuk-body">The UK Cross Government Software Community  site sets a number of cookies to remember what you have done on the site and what messages you have seen.</p>
+        <h4 class="govuk-heading-s">Our cookie message</h4>
+        <table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Name</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-two-thirds">Purpose</th>
+      <th scope="col" class="govuk-table__header">Expiry</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">cm-user-preferences</th>
+         <td class="govuk-table__cell">Stores your cookie preferences and lets us know you’ve set them</td>  
+          <td class="govuk-table__cell">1 year</td>
+        </tr>
+  </tbody>
+  </table>
+        <p class="govuk-body">You may see a pop-up cookies message when you first visit Cross Government Software Community  site service. We'll store a cookie so that your computer knows you've seen it and knows not to show it again.</p>
+    </div>
+</div>
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <h3 class="govuk-heading-m">Government services</h3>
+        <p class="govuk-body">Most services we link to are run by different government departments, for example HM Revenue and Customs (HMRC) or the Home Office.</p>
+        <p class="govuk-body">These services may set additional cookies and, if so, will have their own cookies policy.</p>
+        <h4 class="govuk-heading-s">Change your settings</h4>
+        <p class="govuk-body">
+        You can <a href="/cookies/preferences/">change which cookies you're happy for us to use.</a></p>
+    </div>
+</div>

--- a/_includes/layout.njk
+++ b/_includes/layout.njk
@@ -37,36 +37,7 @@
 </head>
 <body class="govuk-template__body">
 {% block bodyStart %}
-  {{ govukCookieBanner({
-    ariaLabel: "Cookies on [name of service]",
-    messages: [
-      {
-        headingText: "Cookies on [name of service]",
-        html: "<p>We use some essential cookies to make this service work.</p>
-               <p>We'd also like to use analytics cookies so we can understand how you use the service and make improvements.</p>",
-        actions: [
-          {
-            text: "Accept analytics cookies",
-            type: "button",
-            name: "cookies",
-            value: "accept"
-          },
-          {
-            text: "Reject analytics cookies",
-            type: "button",
-            name: "cookies",
-            value: "reject"
-          },
-          {
-            text: "View cookies",
-            href: "#"
-          }
-        ]
-      }
-    ]
-  }) }}
-{% endblock %}
-
+ 
 {% block skipLink %}
   {{ govukSkipLink({
     href: "#main-content",
@@ -99,10 +70,7 @@
 {% endblock %}
 <div class="govuk-width-container govuk-body">
 {% block beforeContent %}
-  {{ govukBackLink({
-    href: "#",
-    text: "Back"
-  }) }}
+  
 {% endblock %}
 {% block content %}
         <main class="govuk-main-wrapper " id="main-content" role="main">
@@ -120,12 +88,8 @@
           text: "Help"
         },
         {
-          href: "#2",
-          text: "Cookies"
-        },
-        {
-          href: "#3",
-          text: "Contact"
+          href: "https://uk-cross-government-software-engineering-community.mailchimpsites.com",
+          text: "Join the mailing list"
         },
         {
           href: "#4",

--- a/_includes/layout.njk
+++ b/_includes/layout.njk
@@ -36,7 +36,7 @@
 {% endblock %}
 </head>
 <body class="govuk-template__body">
-{% block bodyStart %}
+ 
  
 {% block skipLink %}
   {{ govukSkipLink({
@@ -53,17 +53,13 @@
     serviceUrl: "#",
     navigation: [
       {
-        href: "#1",
+        href: "/",
         text: "About",
         active: true
       },
       {
-        href: "#2",
-        text: "Events"
-      },
-      {
-        href: "#3",
-        text: "Blog"
+        href: "/resources",
+        text: "Resources"
       }
     ]
   }) }}
@@ -84,16 +80,12 @@
     meta: {
       items: [
         {
-          href: "#1",
-          text: "Help"
-        },
-        {
-          href: "https://uk-cross-government-software-engineering-community.mailchimpsites.com",
+          href: "https://uk-cross-government-software-engineering-community.mailchimpsites.com/",
           text: "Join the mailing list"
         },
         {
-          href: "#4",
-          text: "Terms and conditions"
+          href: "/objectives",
+          text: "Objectives"
         }
       ]
     }

--- a/_site/index.html
+++ b/_site/index.html
@@ -36,56 +36,8 @@
 
 </head>
 <body class="govuk-template__body">
-
-  <div class="govuk-cookie-banner " data-nosnippet role="region" aria-label="Cookies on [name of service]">
-    
-    
-
-    <div class="govuk-cookie-banner__message govuk-width-container"
-    >
-
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        
-        <h2 class="govuk-cookie-banner__heading govuk-heading-m">Cookies on [name of service]</h2>
-        
-
-        <div class="govuk-cookie-banner__content"><p>We use some essential cookies to make this service work.</p>
-               <p>We'd also like to use analytics cookies so we can understand how you use the service and make improvements.</p></div>
-      </div>
-    </div>
-
-      
-      <div class="govuk-button-group">
-        
-          
-            <button value="accept" type="button" name="cookies" class="govuk-button" data-module="govuk-button">
-              Accept analytics cookies
-            </button>
-          
-        
-          
-            <button value="reject" type="button" name="cookies" class="govuk-button" data-module="govuk-button">
-              Reject analytics cookies
-            </button>
-          
-        
-          
-            
-              
-              
-              <a class="govuk-link" href="#">View cookies</a>
-            
-          
-        
-      </div>
-      
-    </div>
-  
-</div>
-
-
-
+ 
+ 
 
   <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 
@@ -152,7 +104,8 @@
               
                 </a>
               
-            </li>     
+            </li>
+          
         
       </ul>
     </nav>
@@ -165,12 +118,40 @@
 
 <div class="govuk-width-container govuk-body">
 
+  
+
+
         <main class="govuk-main-wrapper " id="main-content" role="main">
           
-          <h1>Cross Government Software Community</h1>
-<p>About the community ...</p>
-<p>TECH IPSUM</p>
-<p>Disruptive scrum project business model canvas user experience churn rate founders. Hackathon supply chain assets network effects user experience. Release partnership investor business-to-business stealth hypotheses ramen user experience traction. IPad client niche market churn rate seed money stock agile development investor virality pitch return on investment. Supply chain beta graphical user interface conversion business-to-business churn rate funding crowdsource direct mailing bandwidth. Holy grail metrics market virality supply chain niche market startup pitch infrastructure responsive web design business plan first mover advantage crowdfunding. IPad paradigm shift sales assets influencer direct mailing creative business plan. Hypotheses lean startup non-disclosure agreement funding business-to-business investor customer focus backing supply chain series A financing. User experience twitter supply chain rockstar. Infrastructure low hanging fruit influencer focus graphical user interface monetization android advisor disruptive pivot seed round traction mass market A/B testing.</p>
+          <h1>Welcome to the Cross Government Software Engineering Community</h1>
+<h2>Who are we</h2>
+<p>We are a group of engineers working in software engineering across government, some of us are hands on developers, others working in other technical or management roles.</p>
+<h2>Vision</h2>
+<p>To provide a forum for collaboration for software engineers across government</p>
+<ul>
+<li>To learn and to teach</li>
+<li>To share ideas</li>
+<li>To have some fun</li>
+</ul>
+<h2>How are we doing this</h2>
+<ul>
+<li>Running monthly virtual lean coffee sessions</li>
+<li>Developing our GitHub repo</li>
+<li>Looking to run more themed events</li>
+<li>Hosting a virtual software engineering meetup in 2022</li>
+<li>We have a small facilitation group that is doing some of the initial setup</li>
+</ul>
+<h2>We want you to be part of this - why not get involved?</h2>
+<ul>
+<li>Signup to our <a href="https://uk-cross-government-software-engineering-community.mailchimpsites.com/">email mailing list on mail chimp</a> - You'll need to signup with your gov email address</li>
+</ul>
+<p>You will get a welcome email and will then be added onto our mailing list of events going forward.</p>
+<ul>
+<li>Check out our <a href="https://github.com/uk-x-gov-software-community/">GitHub Repo</a></li>
+<li>Check out our <a href="https://www.khub.net/group/cross-government-software-engineering-community">Knowledge Hub Group and discussion forum</a></li>
+</ul>
+<h2>Do you want to help facilitate the group ?</h2>
+<p>Drop an email to <a href="mailto:Andy.Poole@ukho.gov.uk">Andy Poole</a> or <a href="mailto:david.heath@digital.cabinet-office.gov.uk">David Heath</a> and one of us can add you to the facilitators group</p>
 
         </main>
 
@@ -187,26 +168,14 @@
             <ul class="govuk-footer__inline-list">
               
                 <li class="govuk-footer__inline-list-item">
-                  <a class="govuk-footer__link" href="#1">
-                    Help
+                  <a class="govuk-footer__link" href="https://uk-cross-government-software-engineering-community.mailchimpsites.com/">
+                    Join the mailing list
                   </a>
                 </li>
               
                 <li class="govuk-footer__inline-list-item">
-                  <a class="govuk-footer__link" href="#2">
-                    Cookies
-                  </a>
-                </li>
-              
-                <li class="govuk-footer__inline-list-item">
-                  <a class="govuk-footer__link" href="#3">
-                    Contact
-                  </a>
-                </li>
-              
-                <li class="govuk-footer__inline-list-item">
-                  <a class="govuk-footer__link" href="#4">
-                    Terms and conditions
+                  <a class="govuk-footer__link" href="/objectives">
+                    Objectives
                   </a>
                 </li>
               

--- a/_site/index.html
+++ b/_site/index.html
@@ -134,7 +134,7 @@
           
             <li class="govuk-header__navigation-item govuk-header__navigation-item--active">
               
-                <a class="govuk-header__link" href="#1">
+                <a class="govuk-header__link" href="/">
               
                 About
               
@@ -146,26 +146,13 @@
           
             <li class="govuk-header__navigation-item">
               
-                <a class="govuk-header__link" href="#2">
+                <a class="govuk-header__link" href="/resources">
               
-                Events
-              
-                </a>
-              
-            </li>
-          
-        
-          
-            <li class="govuk-header__navigation-item">
-              
-                <a class="govuk-header__link" href="#3">
-              
-                Blog
+                Resources
               
                 </a>
               
-            </li>
-          
+            </li>     
         
       </ul>
     </nav>
@@ -177,10 +164,6 @@
 
 
 <div class="govuk-width-container govuk-body">
-
-  <a href="#" class="govuk-back-link">Back</a>
-
-
 
         <main class="govuk-main-wrapper " id="main-content" role="main">
           


### PR DESCRIPTION
I have removed cookie stuff (banner etc left in the cookie page not linked too)  and added objectives and just a single resources item in the menu so if @RobJohnson-HO  just names his file resources.md everything should just work
Linked to Mailchimp in footer so on all pages

![1629823286156](https://user-images.githubusercontent.com/79883/130656297-f1ae1dac-a460-4c0d-ae94-1f0516ddbde4.png)
![1629823364978](https://user-images.githubusercontent.com/79883/130656344-fc3fa623-3b55-484d-a7ae-ddd3fe16b787.png)
