### PR TITLE
Add inclusive hiring details to special interest page

### DIFF
--- a/special-interest.md
+++ b/special-interest.md
@@ -11,8 +11,13 @@ title: Events
 
 ---
 
-### Recruitment Diversity
+### Inclusive Recruitment
 
+[Our aim](https://github.com/uk-x-gov-software-community/community-space/blob/main/special-interest-meetings/inclusive-recruitment/2023-08-09.md#1-goal) is to increase the diversity of software engineers and other technical disciplines across government. We plan to do this by creating resources to support the development of more inclusive hiring practices, advocating and signposting people to these good practices and building a community where people can share ideas and discuss improving practices.
+
+Contact: Eleanor Deal (eleanor.deal@ons.gov.uk or on x-gov Slack)
+
+Meetings: Every 4-6 weeks, for 1 hour. We will review progress on creating resources, prioritise what resources to create next, and leave space to discuss ongoing recruitment campaigns if people want feedback on their own processes or job ads
 
 ---
 


### PR DESCRIPTION
Once we're a bit more settled I might be able to update the meeting cadence to be more specific, but hopefully this is enough for a relaunch :) 