### PR TITLE
use updated GDS link

### DIFF
--- a/guides-open-source.md
+++ b/guides-open-source.md
@@ -52,5 +52,5 @@ Specific to x-Gov:
 - [X-UK-Gov Public Repository Leaderboard](https://uk-x-gov-software-community.github.io/xgov-opensource-repo-scraper/)
 - [#open-code x-gov slack channel](https://ukgovernmentdigital.slack.com/archives/C0Q3KG7B8)
 - [Open source meet-up notes](/open-source-meetup-notes)
-- [NHS Open SOurce Programme](https://www.england.nhs.uk/digitaltechnology/open-source/)
+- [NHS Open Source Programme](https://www.england.nhs.uk/digitaltechnology/open-source/)
  

--- a/resources.md
+++ b/resources.md
@@ -7,7 +7,7 @@ title: Resources
 ---
 
 ### Public civil service guidance and standards
-- [The GDS Way](https://gds-way.cloudapps.digital)
+- [The GDS Way](https://gds-way.digital.cabinet-office.gov.uk/)
 - [UKHO](https://github.com/UKHO/docs)
 - [DEFRA](https://github.com/DEFRA/software-development-standards)
 - [DfE](https://technical-guidance.education.gov.uk)


### PR DESCRIPTION
1. There is a HTTP301 permanent redirect from the cloudapps.digital address.
2. Correct case of in "Open Source" link text