### PR TITLE
Feat: Remove banner for conference survey

### DIFF
--- a/index.md
+++ b/index.md
@@ -24,7 +24,6 @@ related:
         
 
 ---
-{% include "banner.njk" %}
 {% include "menu.njk" %}
 
 


### PR DESCRIPTION
Removes the conference survey banner, left the banner template in place for future announcements 