### PR TITLE
Direct enquiries about the HoE SIG to google group managers

### DIFF
--- a/special-interest.md
+++ b/special-interest.md
@@ -49,6 +49,6 @@ Community Goal Coordinate work drive change across the Civil Service in the fiel
 
 *Aim:* To bring together Heads of Engineering from across government to share best practice, discuss common challenges and work together to improve the quality of software engineering across government. A series of talks and discussions will be held to share knowledge and experience. Supported by the CDDO (Central Digital and Data Office) and a group of volunteers from across government. ( Stephen Ford CDDO, Shaun Hare DVSA, David Heath GDS, Andy Poole UKHO, Sebastian Schmieschek CDDO, Hen Wager HMCTS)
 
-*Contact:* cross-government-software-engineering-heads-of-engineering@digital.cabinet-office.gov.uk
+*Contact:* [cross-government-software-engineering-heads-of-engineering+managers@digital.cabinet-office.gov.uk](mailto:cross-government-software-engineering-heads-of-engineering+managers@digital.cabinet-office.gov.uk)
 
 *Slack Channel:* [#heads-of-engineering](https://ukgovernmentdigital.slack.com/archives/C058C1K39NV) on UK Government Digital slack, request an invite for the channel


### PR DESCRIPTION
avoids messages going into the moderation queue