### PR TITLE
Updating events page and adding a banner for the conference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,11 @@ dist
 # Eleventy build output
 _site
 
+# macOS system files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db

--- a/banner.njk
+++ b/banner.njk
@@ -3,8 +3,8 @@
   <div class="govuk-grid-column-two-thirds">
 {% set html %}
   <p class="govuk-notification-banner__heading">
-    You have only a few days left to take our in person conference survey.
-    <a class="govuk-notification-banner__link" href="https://docs.google.com/forms/d/e/1FAIpQLSdO0KMSqbtJCL4JXd-2LMGwGamyMUDOypi445N9FtLIrjxH-w/viewform">Take our conference survey now</a>.
+    In-person Cross Government Software Engineering Conference 2025
+    <a class="govuk-notification-banner__link" href="/conference-2025-01-29/">Register your interest</a>.
   </p>
 {% endset %}
 

--- a/events.md
+++ b/events.md
@@ -7,7 +7,7 @@ title: Events
 
 Our regular lean coffees meetings are on the 4th Thursday of the month at 11.00-12.00. To get an invite please [join the mailchimp list](https://uk-cross-government-software-engineering-community.mailchimpsites.com/) 
 
-Next Lean Coffee: November 2024 (Look below for October)
+Next Lean Coffee: Thursday 28th November 2024 from 11 am to 12 noon
 
 We are planning a virtual short talk event in on 24th October 2024 10:00 - 12:00. Around the theme of recent Government Initiatives. We have speakers from CCDO Engineering Excellence, TechTrack and Top 75 services team. If you would like to know more or have something to present please [contact us](/contact/)
 

--- a/index.md
+++ b/index.md
@@ -24,6 +24,7 @@ related:
         
 
 ---
+{% include "banner.njk" %}
 {% include "menu.njk" %}
 
 


### PR DESCRIPTION
# Events page

Updated with the date for the next lean coffee.

![events page](https://github.com/user-attachments/assets/9e100b06-f8bb-4e59-94d4-844f36fa2672)

# Banner for the conference

**Copy:** Cross Government Software Engineering Conference 2025
**CTA:** Register your interest 
**Linking to:** https://uk-x-gov-software-community.github.io/conference-2025-01-29/

![banner](https://github.com/user-attachments/assets/8c783d15-61ae-4ae9-bcd7-7bb77f1770fd)



