### PR TITLE
feat: add in conference details

### DIFF
--- a/conference-2025-01-29.md
+++ b/conference-2025-01-29.md
@@ -67,6 +67,7 @@ You can book a wide range of hotels in the area through CTM or any other provide
 * ibis London City - Shoreditch
 * Wilde apartments, Commercial street
 * Leman Locke studios, Leman street
+* Travelodge London Central Aldgate East
 
 Please contact us if you need any further information, either using the Cross Government Slack ( in the software development channel ) or by emailing the <a href="mailto:secretariat-engineering-conference@digital.cabinet-office.gov.uk" >organising committee at secretariat-engineering-conference@digital.cabinet-office.gov.uk </a>
 

--- a/conference-2025-01-29.md
+++ b/conference-2025-01-29.md
@@ -53,7 +53,7 @@ N.B. There is no parking on site.
 
 ### On the day
 
-Please remember to bring a valid form of ID and, where applicable, a Civil Service pass.
+Please remember to bring a valid form of ID and preferably a Civil Service pass.
 On the day you will also be given a conference pass to keep with you at all times, so that you can access the areas reserved for the event.
 You will be able to use GovWifi on the premises.
 Food and beverages, including tea and coffee, will be provided, please contact the organising committee if you have any specific request (secretariat-engineering-conference@digital.cabinet-office.gov.uk).

--- a/conference-2025-01-29.md
+++ b/conference-2025-01-29.md
@@ -5,27 +5,69 @@ title: Cross Government Software Engineering Conference 2025
 
 ![Drawing with stylised people with laptops at a table discussing code](/assets/images/conference.png)
 
-📣 **Register your interest for the Cross Government Software Engineering Conference 2025**
-
-The [Cross Government Software Engineering Community](https://uk-x-gov-software-community.github.io/) is excited to invite you to **[register your interest](https://www.eventbrite.com/e/cross-government-software-engineering-conference-2025-tickets-1044870805707?aff=oddtdtcreator)** for the upcoming in-person **Cross Government Software Engineering Conference**!
 
 On Wednesday, 29th January 2025, we will be hosting an in-person conference in London, bringing together members of the community for an exciting day of talks, discussions, and networking. 
 
-Whether you’re a seasoned developer or just starting on your career journey, this is the perfect event to meet others from across the government delivering digital services.
 
-## Ticketing Information
-This event has a limited capacity. Therefore, to ensure a diverse representation from across government departments, tickets will be allocated in two releases:
+<a href="#the-agenda-of-the-event" title="agenda" >Agenda of the event</a>
+<a href="#the-venue" title="venue" >The venue </a>
+<a href ="#how-to-get-there" title= "How to get there" >How to get there </a>
+<a href="#on-the-day" title="On the day"> On the day </a>
+<a href= "#if-you-are-staying-overnight" title="If you are staying overnight">If you are staying overnight</a>
 
-* **Release 1**: Registration opens, and everyone will be able to register for the wait list. Tickets will be allocated to the first two people who register from each department/agency.
 
-* **Release 2**: On **1st December**, if there are any remaining spaces, tickets will be allocated on a first-come, first-served basis to those on the waiting list, with a maximum of 10 tickets per department/agency.
+### The Agenda of the event 
+The Cross Government Software Engineering Conference will take place on Wednesday, 29th January 2025 from 9 AM to 5PM, social (optional) from 5PM onwards. Below the breakdown of the sessions:
 
-## Submit your lightning talk
+| Time |  Main Room | Breakout room 1 |
+|-----|---|---|
+| 09:00 - 10:30 | Registration | |
+| 10:30 - 11:30 |  Keynote - Asmin Hussian, Green Software Foundation (with Q&A)
+| 11:30 - 13:00 | Lightning Talks (6 sessions with Q&A) | Lean Coffee Session |
+| 13:00 - 14:00 | Lunch ||
+| 14:00 - 15:00 |  Keynote - Terence Eden, Lessons learned Open Sourcing the UK's Covid Tracing App ||
+| 15:00 - 16:30 |  Deep-dive tech sessions | Lean Coffee Session |
+|15:20 - 15:40 | GOV.UK One Login: What, Why and How - Phil Fordham & Paul Dougan | Lean Coffee Session |
+| 15:40 - 16:00 |Applying AI to the Legislative Process - Liam Wilkinson (i.AI) | Lean Coffee Session |
+| 16:00 - 16:20 | Evolving GOV.UK Chat from Prototype to Production AI System - Alessia Tosi, Kevin Dew and Rich Eveson | Lean Coffee Session |
+| 16:20 - 16:30 | Break ||
+| 16:30 - 17:00 | Closing Session - X-Gov Software Dev Community and How to Get Involved ||
 
-As part of the conference schedule, you have the opportunity to give a 10-minute lightning talk on a topic of your choice. 
 
-If you have an interesting, funny, frustrating or inspiring story from your time working in government, **[please submit a talk title and brief description via our form](https://docs.google.com/forms/d/e/1FAIpQLSdPAm-_gH6r9TAXBzsplKvCANWEI3kZJYEmlo2UA-uFs2KdnA/viewform?usp=sf_link)**. We have up to 6 spaces for these 10-minute talks (including optional 5 minutes for questions).
+Social (optional) 5PM onwards
+Join us after the conference at The Running Horse pub from 5:00 PM onwards. The venue offers a wide selection of craft beers and food options catering to all dietary requirements.
 
-Submissions will be reviewed by the conference organising committee. If your talk is accepted, you will be guaranteed a ticket.
+### The Venue
+The event will take place at the Whitechapel building, 10 Whitechapel High St, London E1 8QS.
+The event will be hosted at the GDS offices, on the 7th floor of the building.
+1 week before the event you will receive an email with a day pass to access the building: you will need to activate your day pass at the ground floor reception by showing your ID and this email. You will need to keep the pass with you all day to enter and leave the venue.
+You will also need to request a visitor pass at the office reception on the 7th floor: please bring your Civil Service pass with you to receive an unescorted visitor pass.
+Don't worry: organisers will be available on the floors to direct you and help you get access!
 
-**We look forward to seeing you at the conference!**
+### How to get there
+The venue is located in Zone 1, and efficiently connected by several public transport lines. The nearest stations are:
+* Liverpool Street (west) - 7-minute walk
+* Aldgate and Aldgate East - 1-minute walk
+
+N.B. There is no parking on site.
+
+### On the day
+
+Please remember to bring a valid form of ID and, where applicable, a Civil Service pass.
+On the day you will also be given a conference pass to keep with you at all times, so that you can access the areas reserved for the event.
+You will be able to use GovWifi on the premises.
+Food and beverages, including tea and coffee, will be provided, please contact the organising committee if you have any specific request (secretariat-engineering-conference@digital.cabinet-office.gov.uk).
+The venue also has cutlery, glasses and mugs for everyone to use: however, as we will use the office premises, please bring your own mug/flask to minimise disruption to colleagues working.
+
+### If you are staying overnight
+You can book a wide range of hotels in the area through CTM or any other provider (just make sure  they are within the budget policy for London). However we would sugesst the following close by hotels:
+
+* Holiday Inn Whitechapel
+* Hub by Premier Inn London Spitalfields
+* ibis London City - Shoreditch
+* Wilde apartments, Commercial street
+* Leman Locke studios, Leman street
+
+Please contact us if you need any further information, either using the Cross Government Slack ( in the software development channel ) or by emailing the <a href="mailto:secretariat-engineering-conference@digital.cabinet-office.gov.uk" >organising committee at secretariat-engineering-conference@digital.cabinet-office.gov.uk </a>
+
+

--- a/conference-2025-01-29.md
+++ b/conference-2025-01-29.md
@@ -26,7 +26,7 @@ The Cross Government Software Engineering Conference will take place on Wednesda
 | 11:30 - 13:00 | Lightning Talks (6 sessions with Q&A) | Lean Coffee Session |
 | 13:00 - 14:00 | Lunch ||
 | 14:00 - 15:00 |  Keynote - Terence Eden, Lessons learned Open Sourcing the UK's Covid Tracing App ||
-| 15:00 - 16:30 |  Deep-dive tech sessions | Lean Coffee Session |
+| 15:00 - 15:20 |  Tech Talk TBC | Lean Coffee Session |
 |15:20 - 15:40 | GOV.UK One Login: What, Why and How - Phil Fordham & Paul Dougan | Lean Coffee Session |
 | 15:40 - 16:00 |Applying AI to the Legislative Process - Liam Wilkinson (i.AI) | Lean Coffee Session |
 | 16:00 - 16:20 | Evolving GOV.UK Chat from Prototype to Production AI System - Alessia Tosi, Kevin Dew and Rich Eveson | Lean Coffee Session |

--- a/events.md
+++ b/events.md
@@ -7,9 +7,9 @@ title: Events
 
 Our regular lean coffees meetings are on the 4th Thursday of the month at 11.00-12.00. To get an invite please [join the mailchimp list](https://uk-cross-government-software-engineering-community.mailchimpsites.com/) 
 
-Next Lean Coffee: Thursday 28th November 2024 from 11 am to 12 noon
+## 2025
 
-We are planning a virtual short talk event in on 24th October 2024 10:00 - 12:00. Around the theme of recent Government Initiatives. We have speakers from CCDO Engineering Excellence, TechTrack and Top 75 services team. If you would like to know more or have something to present please [contact us](/contact/)
+* 27th February 2025 - Virtual - 11:00 - 12:00 - Lean Coffee
 
 We are pleased to invite you also to the in-person [Cross Government Software Engineering Conference 2025](/conference-2025-01-29/)!
 
@@ -24,6 +24,11 @@ Here are the next meetings for the **Heads of Engineering Special Interest Group
 If you wish to join this interest group, please [contact us](/special-interest/#heads-of-engineering) 
 
 # Past Events
+
+## 2024
+Thursday 28th November 2024 from 11 am to 12 noon
+
+A virtual short talk event in on 24th October 2024 10:00 - 12:00. Around the theme of recent Government Initiatives. We have speakers from CCDO Engineering Excellence, TechTrack and Top 75 services team. 
 
 ## 2022
 

--- a/index.md
+++ b/index.md
@@ -24,7 +24,6 @@ related:
         
 
 ---
-{% include "banner.njk" %}
 {% include "menu.njk" %}
 
 


### PR DESCRIPTION
Added in conference details from the email to provide point of reference 

Do we want a link from homepage ? I would suggest we need something to help attendees navigate 

![image](https://github.com/user-attachments/assets/00243d95-ffd8-4a26-875b-562c6a1857c6)
