### PR TITLE
fix: added a note on conference page

### DIFF
--- a/banner.njk
+++ b/banner.njk
@@ -3,9 +3,12 @@
   <div class="govuk-grid-column-two-thirds">
 {% set html %}
   <p class="govuk-notification-banner__heading">
-    Joining us at our In-person Cross Government Software Engineering Conference 2025 ?
-    <a class="govuk-notification-banner__link" href="/conference-2025-01-29/">All you need to know here </a>.
+    It is over ... 
+    <p class="ovuk-notification-banner__body">Thanks to all those who attended the In-person Cross Government Software Engineering Conference 2025, also thanks to volunteers.</p>
+    <p class="govuk-notification-banner__body"> 
+    <strong>Especially a big thank you UK GovCamp for the sponsorship <a class="govuk-notification-banner__link" href="https://www.ukgovcamp.com/grants/">from their grant scheme</a>.</strong
   </p>
+  <p class="govuk-notification-banner__body"> We will aim to write a blog post soon. </p>
 {% endset %}
 
 {{ govukNotificationBanner({

--- a/conference-2025-01-29.md
+++ b/conference-2025-01-29.md
@@ -5,6 +5,7 @@ title: Cross Government Software Engineering Conference 2025
 
 ![Drawing with stylised people with laptops at a table discussing code](/assets/images/conference.png)
 
+{% include "banner.njk" %} 
 
 On Wednesday, 29th January 2025, we will be hosting an in-person conference in London, bringing together members of the community for an exciting day of talks, discussions, and networking. 
 

--- a/events.md
+++ b/events.md
@@ -5,14 +5,13 @@ title: Events
 
 # Upcoming Events  
 
+
 Our regular lean coffees meetings are on the 4th Thursday of the month at 11.00-12.00. To get an invite please [join the mailchimp list](https://uk-cross-government-software-engineering-community.mailchimpsites.com/) 
 
 ## 2025
-* 29th January 2025 - In Person - 9:00 - 17:00 - [Cross Government Software Engineering Conference 2025](/conference-2025-01-29/)!
-
 * 27th February 2025 - Virtual - 11:00 - 12:00 - Lean Coffee
 
-
+We just ran * 29th January 2025 - In Person Conference  - 9:00 - 17:00 - [Cross Government Software Engineering Conference 2025 see details ](/conference-2025-01-29/)!
 
 ## Special Interest Groups
 

--- a/menu.njk
+++ b/menu.njk
@@ -18,9 +18,9 @@
 <div class="govuk-grid-row">
 <section class="govuk-grid-column-one-half govuk-!-margin-bottom-4">
     <h3 class="govuk-heading-m govuk-!-margin-bottom-2">
-      <a class="govuk-link" href="/events">Events</a>
+      <a class="govuk-link" href="/events">Events, News and Blog</a>
     </h3>
-    <p class="govuk-body">Our events include lightning talks and unconferences</p>
+    <p class="govuk-body">Learn about our news and events which include lightning talks and unconferences and In-person conferences.</p>
   </section>
   <section class="govuk-grid-column-one-half govuk-!-margin-bottom-4">
     <h3 class="govuk-heading-m govuk-!-margin-bottom-2">


### PR DESCRIPTION
Added a banner on conference page offer thanks and ensuring someone knows it is over 

<img width="1098" alt="Screenshot 2025-01-31 at 00 04 11" src="https://github.com/user-attachments/assets/a7c679b4-a511-4121-9d5e-0e484ee29fd1" />
