### PR TITLE
Fix broken link to Slack (+ misc. tidying up)

### DIFF
--- a/lean-coffee.md
+++ b/lean-coffee.md
@@ -11,7 +11,6 @@ Lean Coffee is a structured, but agenda-less meeting. see [the lean coffee websi
 
 You do not need to bring any content in advance we will ask people to contribute topics on the session, however if you do have or think of something you want to discuss with the group you can add it to our HackMd before hand.
 
- Please contact group facilitators - [Andy Poole](mailto:Andy.Poole@ukho.gov.uk) or [David Heath](mailto:david.heath@digital.cabinet-office.gov.uk) or [Shaun Hare](mailto:shaun.hare@dvsa.gov.uk) if you need assistance adding topics or want to learn more. Or reach out in the #software-development channel on [UK Government Digital Slack](ukgovernmentdigital.slack.com)
+ Please contact group facilitators - [Andy Poole](mailto:Andy.Poole@ukho.gov.uk) or [David Heath](mailto:david.heath@digital.cabinet-office.gov.uk) or [Shaun Hare](mailto:shaun.hare@dvsa.gov.uk) if you need assistance adding topics or want to learn more. Or reach out in the #software-development channel on [UK Government Digital Slack](https://ukgovernmentdigital.slack.com/)
 
  We would really like to see as many Government Sofware Engineers (Architects/ Heads of Engineering / Software Testers - basically any one who writes code for public services in UK Government and associated bodies / organisations) at these sessions you are very welcome.
-

--- a/lean-coffee.md
+++ b/lean-coffee.md
@@ -3,14 +3,24 @@ layout: page.njk
 title: Lean Coffee
 ---
 
-Our Lean coffees are held monthly on 4th Thursday of the month at 11.00-12.00.
+Our Lean Coffees are held on the fourth Thursday of each month at 11am to midday.
 
-### What is a lean coffee and how does it work?
+### How 'Lean Coffee' works
 
-Lean Coffee is a structured, but agenda-less meeting. see [the lean coffee website](http://leancoffee.org/) for more information. We have a [HackMd](https://hackmd.io/) / Kanban board set up and we as a community populate it with ideas. We then vote for ideas, start discussing in a timeboxed session and vote whether to continue discussing or move on to the next idea at the end of the timebox.
+Lean Coffee is a structured but agenda-less meeting. See [the Lean Coffee website](http://leancoffee.org/) for more information.
 
-You do not need to bring any content in advance we will ask people to contribute topics on the session, however if you do have or think of something you want to discuss with the group you can add it to our HackMd before hand.
+As a community, we populate a [HackMd](https://hackmd.io/) Kanban board with ideas. We then vote for ideas, start discussing in a timeboxed session, and vote whether to continue discussing or move on to the next idea at the end of the timebox.
 
- Please contact group facilitators - [Andy Poole](mailto:Andy.Poole@ukho.gov.uk) or [David Heath](mailto:david.heath@digital.cabinet-office.gov.uk) or [Shaun Hare](mailto:shaun.hare@dvsa.gov.uk) if you need assistance adding topics or want to learn more. Or reach out in the #software-development channel on [UK Government Digital Slack](https://ukgovernmentdigital.slack.com/)
+You do not need to bring any content in advance. We will ask people to contribute topics in the session, however if you have something you want to discuss with the group, you can add it to our HackMd beforehand.
 
- We would really like to see as many Government Sofware Engineers (Architects/ Heads of Engineering / Software Testers - basically any one who writes code for public services in UK Government and associated bodies / organisations) at these sessions you are very welcome.
+### Getting in touch
+
+Please contact the group facilitators if you need assistance adding topics or want to learn more:
+
+* [Andy Poole](mailto:Andy.Poole@ukho.gov.uk)
+* [David Heath](mailto:david.heath@digital.cabinet-office.gov.uk)
+* [Shaun Hare](mailto:shaun.hare@dvsa.gov.uk)
+
+Or reach out in the `#software-development` channel on [UK Government Digital Slack](https://ukgovernmentdigital.slack.com/).
+
+We would really like to see as many government software engineers (including architects, heads of engineering, software testers) at these sessions as possible. Anyone who writes code for public services in UK government and associated bodies or organisations is very welcome.


### PR DESCRIPTION
The link to the UK Government Digital Slack on the Lean Coffee page is broken as it's currently missing a protocol (and instead tries to interpret `ukgovernmentdigital.slack.com` as a relative path). This is corrected by prepending `https://` to explicitly state the URL protocol.

While having a look at `lean-coffee.md`, I noticed a couple of other random formatting hiccups, so also ended up applying those fixes and correcting some bits of missing punctuation.

This then transpired into updating some phrasing and grammar within the document to align with the [GDS style guide](https://www.gov.uk/guidance/style-guide/a-to-z)!