### PR TITLE
add draft tor

### DIFF
--- a/menu.njk
+++ b/menu.njk
@@ -1,8 +1,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-<h1 class="govuk-heading-l">Learn about</h1>
-</div>
-<section class="govuk-grid-column-one-half govuk-!-margin-bottom-4">
+  <h1 class="govuk-heading-l">Learn about</h1>
+  </div>
+  <section class="govuk-grid-column-one-half govuk-!-margin-bottom-4">
     <h3 class="govuk-heading-m govuk-!-margin-bottom-2">
       <a class="govuk-link" href="/lean-coffee">Our Lean Coffee sessions</a>
     </h3>
@@ -10,13 +10,13 @@
   </section>
   <section class="govuk-grid-column-one-half govuk-!-margin-bottom-4">
     <h3 class="govuk-heading-m govuk-!-margin-bottom-2">
-      <a class="govuk-link" href="/special-interest">Special Interest groups</a>
+      <a class="govuk-link" href="/tor">Draft Terms of Reference</a>
     </h3>
-    <p class="govuk-body">We publish and promote special interest groups run by our community</p>
+    <p class="govuk-body">Review our draft terms of reference</p>
   </section>
 </div>
 <div class="govuk-grid-row">
-<section class="govuk-grid-column-one-half govuk-!-margin-bottom-4">
+  <section class="govuk-grid-column-one-half govuk-!-margin-bottom-4">
     <h3 class="govuk-heading-m govuk-!-margin-bottom-2">
       <a class="govuk-link" href="/blog">Events, News and Blog</a>
     </h3>
@@ -27,5 +27,13 @@
       <a class="govuk-link" href="/resources">Resources created by our community</a>
     </h3>
     <p class="govuk-body">Newsletter, open source projects, other resources such as coding guides and AI policies all created by and for the community</p>
+  </section>
+</div>
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-one-half govuk-!-margin-bottom-4">
+    <h3 class="govuk-heading-m govuk-!-margin-bottom-2">
+      <a class="govuk-link" href="/special-interest">Special Interest groups</a>
+    </h3>
+    <p class="govuk-body">We publish and promote special interest groups run by our community</p>
   </section>
 </div>

--- a/tor.md
+++ b/tor.md
@@ -1,0 +1,183 @@
+---
+layout: product
+title: Terms of Reference
+description: Draft Terms of Reference for the UK Cross Government Software Engineering Community
+---
+
+# Introduction
+
+This page shows our draft terms of reference. 
+
+If you wish to comment on the TOR, you can comment on the [open pull request](https://github.com/uk-x-gov-software-community/community-space/pull/49) in our [community space](https://uk-x-gov-software-community.github.io/community-space/). 
+
+The TOR will be adopted at our first AGM in Aug/Sept 2025 (Date TBC). 
+
+----------
+
+# Cross Government Software Engineering Community - Terms of Reference (DRAFT)
+
+## Purpose and authority
+
+The Cross Government Software Engineering Community is a voluntary association of Software Engineers/Developers working in the UK Civil Service. 
+
+We exist to foster collaboration, knowledge sharing, and professional development among software engineers and related roles across the UK Government. We do this by running online and in-person events such as lean coffee meetings, special interest groups and conferences.
+
+We aim to be recognised as a source of expertise on Software Engineering/Development practice, on the Software Engineering profession and to act as a key stakeholder to the Government Digital and Data Function. 
+
+We do not set or define government policy or standards.
+
+## Objectives
+
+Our objectives, as of May 2025 are:
+
+1. **Connect development teams across government** - by running community networking and knowledge sharing events  
+2. **Learning and development** - facilitate sharing of techniques, materials and approaches that support learning and development for developers and software engineers  
+3. **Championing standards** - facilitate the sharing of software engineering standards and good practice   
+4. **Promoting diversity and inclusion** - through advocacy and connecting work between departments to share good practice  
+5. **Represent the software engineering community in Government Digital and Data profession forums** 
+
+Our objectives will be revised at least annually at the discretion of the management committee and [published on our website](https://uk-x-gov-software-community.github.io/objectives/).
+
+## Membership
+
+The scope of our membership and activities is aligned with the [Government Digital and Data Function](https://www.gov.uk/government/publications/government-functions/government-functions). As such our primary focus is on [Central Government departments and arms length bodies](https://www.gov.uk/government/organisations), but we are open to participation from the wider public sector. We invite anyone aligned with the "[Software Developer](https://ddat-capability-framework.service.gov.uk/role/software-developer)" role in the GDaD framework to participate in our community. 
+
+To be a **member** of the community you:
+
+1. must be currently working as a software developer, software engineer or software engineering manager in either:  
+   1. a [central government department or arms-length body](https://www.gov.uk/government/organisations)  
+   2. a [devolved national government](https://www.gov.uk/government/organisations#devolved_governments)  
+   3. local government  
+   4. the NHS  
+   5. the Police  
+2. must be either a civil servant, interim/contractor or from a service provider  
+3. agree to support the aims and objectives of the community  
+4. agree not to use the community to promote your commercial interests, without prior written agreement from the management committee
+
+Anyone who has been an approved member of our email list for at least six weeks is considered a community member eligible to vote at our Annual General Meeting.
+
+## Code of Conduct
+
+The Cross Government Software Engineering Community is committed to fostering a welcoming, inclusive, and professional environment for all members regardless of gender, sexual orientation, disability, preferred programming language, technical experience, ethnicity, socioeconomic status, and religion (or lack thereof). We invite all who participate in the community to help us create safe and positive experiences for everyone. 
+
+This Code of Conduct outlines the expected behavior and standards for all participants.
+
+### General Principles
+
+* **Respect:** Treat all members with courtesy, respect, and consideration, regardless of background, experience, or viewpoint.  
+* **Inclusivity:** Actively contribute to creating a diverse and inclusive community where everyone feels valued and has the opportunity to participate.  
+* **Professionalism:** Conduct yourself in a professional manner, both online and in-person, maintaining high standards of integrity and ethical behavior.  
+* **Collaboration:** Encourage and support collaboration, knowledge sharing, and mutual learning among members.  
+* **Responsibility:** Take responsibility for your actions and their impact on others within the community.
+
+### Specific Guidelines
+
+* **Civil Service Code:** All members are expected to uphold the principles of the Civil Service Code, including integrity, honesty, objectivity, and impartiality.  
+* **Communication:** Communicate respectfully and avoid personal attacks, harassment, or discriminatory language. Constructive feedback is encouraged but should be delivered in a positive and supportive manner.  
+* **Participation:** Actively participate in community events and discussions in a positive and constructive way. Share your knowledge and experience, and be open to learning from others.  
+* **Confidentiality:** Respect the confidentiality of information shared within the community, particularly when discussing sensitive topics or projects.  
+* **Intellectual Property:** Acknowledge and respect intellectual property rights. Do not share or use copyrighted material without permission.  
+* **Commercial Interests:** Refrain from using the community to promote commercial interests or solicit business without prior written agreement from the Management Committee.  
+* **Dispute Resolution:** If you experience or witness behavior that violates this Code of Conduct, report it to the Management Committee. The committee will address concerns fairly and impartially.  
+* **Enforcement:** The Management Committee reserves the right to take appropriate action, including removing individuals from the community, for violations of this Code of Conduct.
+
+### Arbitration
+
+* In cases of disputes or alleged violations of the Code of Conduct, the Management Committee will conduct a fair and impartial review.  
+* The committee may seek input from relevant parties and make decisions based on the facts and evidence available.  
+* Decisions made by the Management Committee regarding Code of Conduct violations are final.
+
+### Review and Updates
+
+This Code of Conduct will be reviewed and updated periodically by the Management Committee to ensure it remains relevant and effective.
+
+### Reporting a concern
+
+To report a concern relating to any violation or potential violation of the code of conduct, please use our confidential reporting form linked on our website which will be picked up by a member of the management committee and handled in confidence. 
+
+If your concern relates to a management committee member, you may approach another management committee member directly in the first instance. 
+
+## Management committee
+
+The Management Committee leads the Cross Government Software Engineering Community and sets its strategic direction. 
+
+The committee's responsibilities include:
+
+* organizing meetings and curating an events program  
+* managing tools or systems that support community activities, including GDPR compliance  
+* communications and social media presence  
+* maintains meeting minutes
+
+The management committee comprises the following roles which will be elected annually at our Annual General Meeting:
+
+1. **Chair**: Leads the community and sets strategic direction.  
+2. **Secretary**: Organizes meetings of the management committee, ensure that the meetings are minuted and actions communicated  
+3. **Infrastructure officer**:   
+   1. manage the website  
+   2. manage mailchimp sync  
+   3. manage the github organisation  
+   4. acts as our Data Protection Officer and ensures compliance with GDPR  
+4. **Communications officer**: Manages external communication through our email list, blogging, mailchimp list, coordinate newsletter (stretch goal)  
+5. **Social media officer**: develop our presence on social media  
+6. **Events officer:** coordinate and curate our events programme including Lean Coffee, liaise with SIGs to ensure a coherent overall events programme
+
+SIG Leads can attend the Management committee to observe, to provide updates or to present proposals but do not have voting rights on the management committee.
+
+Additional officers can be co-opted at any time by decision of the management committee. Co-opted officers serve until the next election (when they could stand for election). 
+
+### Minutes
+
+Minutes of the Management Committee will be posted by the secretary in our github community space. 
+
+### Quorum
+
+The management committee is quorate if at least the following are present:
+
+1. the chair or their designated representative  
+2. the secretary or their designated representative  
+3. one other officer
+
+### Decision making
+
+Decisions are ideally made by consensus. In the absence of consensus, decisions will be made by a majority vote of the members present, and the chair will have the casting vote.
+
+### Meetings
+
+The management committee will meet monthly, usually virtually. The secretary will arrange meetings and maintain an email distribution list and a private slack channel in Cross Government Slack (ukgovernmentdigital.slack.com) corresponding to the committee membership.
+
+### AGM, EGM and Elections
+
+Elections will be held at the Annual General Meeting (AGM). 
+
+The AGM will be held no later than 13 Months after the previous AGM. 
+
+Officers will serve for a 1 year term (or until the next AGM), for a maximum of 3 years. 
+
+Notice of the AGM will be issued to members by the secretary no less than 3 weeks in advance. Notice will include the agenda, location (usually an online meeting), date and time. 
+
+An AGM requires the same quorum as the Management committee. 
+
+The management committee can call an Extraordinary General Meeting at any time. The notice period and conditions of the AGM apply. 
+
+### Accountability
+
+The community is primarily accountable to its members through its ongoing active engagement and events, and through the AGM. 
+
+All community members are required to uphold the Civil Service Code.
+
+## Special Interest Groups
+
+Special Interest Groups (SIG) can be created or disbanded by decision of the management committee. 
+
+Each special interest group must nominate a SIG lead who attends the Management committee as an observer. 
+
+The Management team Secretary will maintain an email list for the management committee of each SIG. 
+
+The SIG lead should promptly notify the secretary of any changes to membership of each group. 
+
+Each SIG should also:
+
+* ensure information about forthcoming events is published on the website and other comms channels, working with the Communications officer  
+* maintain notes about each meeting in the github community space [https://github.com/uk-x-gov-software-community/community-space](https://github.com/uk-x-gov-software-community/community-space)
+
+A SIG which has not met for 6 months or more will be considered defunct and will be closed down.


### PR DESCRIPTION
so that it shows up on our website

in this publicly visible draft, I've linked to a [PR in our community space](https://github.com/uk-x-gov-software-community/community-space/pull/49/) where we invite comments on the content of the TOR

# Screenshot 1 - home page

![Screenshot 2025-06-02 at 23 21 46](https://github.com/user-attachments/assets/cd96e865-bca2-4e06-8dbb-d21fea6a8a5f)

# Screenshot 2 - content page 

![screencapture-localhost-8081-tor-2025-06-02-23_21_56](https://github.com/user-attachments/assets/9cc1b74c-9335-442f-8e03-80a696225172)

