### PR TITLE
Add The MHCLG Way to the list of public CS guidance

### DIFF
--- a/resources.md
+++ b/resources.md
@@ -17,6 +17,7 @@ title: Resources
 - [CDDO API technical and data standards](https://www.gov.uk/guidance/gds-api-technical-and-data-standards)
 - [NHS Business Services Authority playbook](https://nhsbsa.github.io/nhsbsa-digital-playbook/)
 - [HMCTS](https://hmcts.github.io)
+- [The MHCLG Way](https://communitiesuk.github.io/mhclg-way/)
 
 ---
 ### Colleagues outside of UK Government


### PR DESCRIPTION
We've been working for a while on getting this clone of The GDS Way in shape fit the current state of play at MHCLG in terms of technologies and practices in the dept and finally got it over the line and published to the world last week by locking 8 people in a room for a day to complete the review and get the content to the point where there's nothing completely wrong in there.

We'll get a vanity domain for it eventually, but hopefully it's OK to share the GitHub pages URL here for the time being.
