### PR TITLE
Added new event and banner

### DIFF
--- a/banner.njk
+++ b/banner.njk
@@ -3,10 +3,10 @@
   <div class="govuk-grid-column-full">
 {% set html %}
   <p class="govuk-notification-banner__heading">
-    Elections 
-    <p class="ovuk-notification-banner__body">Please vote in our upcoming elections.</p>
+    Virtual Event
+    <p class="ovuk-notification-banner__body">Join us for La Suite Numerique Tech Talk, a technical deep dive into the French Government open source project May 7th 11am</p>
     <p class="govuk-notification-banner__body"> 
-    <strong>To view the candidates please see the  <a class="govuk-notification-banner__link" href="/blog/2025/07/elections">election blog post </a>.</strong
+    <strong>To secure a ticket   <a class="govuk-notification-banner__link" href="/events">Sign up on Eventbrite  </a>.</strong
   </p>
 {% endset %}
 

--- a/events.md
+++ b/events.md
@@ -4,7 +4,7 @@ title: Events
 ---
 
 # Upcoming Events  
-
+Join us for La Suite Numerique Tech Talk, a technical deep dive into the French Government open source project May 7th 11am (get tickets)[https://www.eventbrite.co.uk/e/la-suite-numerique-tech-talk-tickets-1985703135532?aff=oddtdtcreator]
 
 Our regular lean coffees meetings are on the 4th Thursday of the month at 11.00-12.00. To get an invite please [join the mailchimp list](https://uk-cross-government-software-engineering-community.mailchimpsites.com/) 
 

--- a/index.md
+++ b/index.md
@@ -27,6 +27,7 @@ related:
      
 
 ---
+{% include "banner.njk" %}
 {% include "menu.njk" %}
 
 


### PR DESCRIPTION
This pull request updates the site's event promotion to highlight an upcoming virtual tech talk and ensures the event announcement is visible across the site. The most important changes are:

Event promotion updates:

* Updated the `banner.njk` notification banner to promote the "La Suite Numerique Tech Talk" virtual event, replacing the previous elections announcement, and included a call-to-action link for ticket sign-up.
* Updated the `events.md` page to feature the tech talk at the top, including a direct link to the Eventbrite ticket page.

Site-wide visibility:

* Added the updated `banner.njk` to the `index.md` file to ensure the event announcement is displayed on the homepage.