### PR TITLE
Update actions-gh-pages from v4.0.0 to v4.1.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
       - run: npm run build
       - run: cp  _site/assets/favicon.*  _site/assets/images/. # fix for  favicon
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4.0.0
+        uses: peaceiris/actions-gh-pages@v4.1.0
         if: github.ref == 'refs/heads/main'
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}

--- a/.github/workflows/deploy-cloudflare-worker.yaml
+++ b/.github/workflows/deploy-cloudflare-worker.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Deploy via Wrangler
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
New version for `peaceiris/actions-gh-pages` has been released. This version updates the NodeJS runtime and hardens the GitHub Actions workflows. This pull request updates the `actions-gh-pages` to a new version.