### PR TITLE
Add conference page for GovDev North 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To develop the website you will need the following.
    ```
 3. to run the site locally 
   ```
-     npx @11ty/eleventy --serve --port=8081
+   npm run dev
    ```
 
 ### Installation (Docker)

--- a/conferences/2026-09-30.md
+++ b/conferences/2026-09-30.md
@@ -1,0 +1,150 @@
+---
+layout: page.njk
+title: GovDev North 2026
+---
+
+![GovDev North 2026 — Cross Government Software Engineering Conference, Newcastle, 30th September](/assets/images/conference-2026/govdev-north-2026.jpg)
+
+
+On Wednesday, 30th September 2026, we will be running an in-person conference in Newcastle with the support of Opencast. Bringing together engineering professionals from across government for an exciting day of talks, discussions, and networking. 
+
+
+<a href="#the-venue" title="venue" >The venue</a>
+<a href ="#how-to-get-there" title= "How to get there" >How to get there</a>
+<a href="#on-the-day" title="On the day"> On the day</a>
+<a href= "#if-you-are-staying-overnight" title="If you are staying overnight">If you are staying overnight</a>
+<a href="#agenda" title="agenda" >Agenda</a>
+<a href="#contact-us" title="contact" >Contact us</a>
+
+### The venue
+
+### How to get there
+
+
+<img src="/assets/images/conference-2026/govdev-north/Newcastle-map2.png"
+     alt="A map of Newcastle with Opencast office highlighted"
+     style="width:60%; display: block; margin: 0 auto;" />
+
+Opencast, Unit 2, The Kiln, Hoults Yard, Newcastle upon Tyne NE6 1AB
+
+[Get directions here.](https://www.google.com/maps?ll=54.9712,-1.580834&z=17&t=m&hl=en-GB&gl=US&mapclient=embed&cid=15898536302670747954)
+
+#### From Newcastle Station
+
+Exit the train station on Neville street, turn right and walk 5 to 10 mins along Collingwood Street (cross to the side of the street with the Revolution bar on it) and Neville Street to reach Grey Street, turn left up Grey Street to reach the [Grey Street bus stop](https://maps.app.goo.gl/2qK7A5b5N18LR53E9). Catch the Q3 Voltra heading to Wallsend, stay on for 6 stops and alight at [Walker Road-Hawick Crescent](https://maps.app.goo.gl/m1rBi8Ev2TM5ikHU6). Head north-east under the old railway bridge (with Hoults painted on it) into Hoults Yard. Walk into the lower car park with the offices on your left hand side, turn left and follow the road to the upper car park. Walk directly up into the car park past Cake Stories on the right hand side until you reach the Tapyard event venue. 
+
+### On the day
+
+Please remember to bring a valid form of ID and preferably a Civil Service pass. On the day you will also be given a conference pass to keep with you at all times, so that you can access the areas reserved for the event.
+Wifi will be available cross both Tapyard and Opencast HQ
+Food and beverages, including tea and coffee, will be provided, please contact the organising committee if you have any specific request ([govdev-north@uk-x-gov-software-community.org.uk](mailto:govdev-north@uk-x-gov-software-community.org.uk)).
+The venue also has cutlery, glasses and mugs for everyone to use: however, as we will use the office premises we recommend bringing your own water bottle and/or hot drinks cup to reduce waste.
+
+### If you are staying overnight
+
+You can book a wide range of hotels in the area through CTM or any other provider. However, we would suggest the following close by hotels:
+
+- Premier Inn Newcastle - Millennium Bridge (to venue: 10min bus, 0.8 mile walk)
+- Travelodge Newcastle Central (to venue: 10min bus, 1 mile walk)
+- Premier Inn Newcastle City Centre - Quayside (to venue: 10min bus, 1.3 mile walk)
+- Ramada Encore Newcastle Gateshead (to venue: 20min bus, 1.3 mile walk)
+
+
+### Agenda
+
+
+| Time            | Tapyard                                                                                                                                                                                                | Opencast kitchen         | Opencast upstairs                       |
+|-----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------|-----------------------------------------|
+| 09:00 - 10:30   | Registration                                                                                                                                                                                           |                          |                                         |
+| 09:00 - 10:30   |                                                                                                                                                                                                        | Welcome teas and coffees |                                         |
+| 10:30 - 11:30   | Keynote and Q&A                                                                                                                                                                                        |                          |                                         |
+| 11:30 - 11:30   | Conference photo                                                                                                                                                                                       |                          |                                         |
+| 11:30 - 11:45   | Break                                                                                                                                                                                                  |                          |                                         |
+| 11:45 - 12:10   | [Friends Don't Let Friends Build Infrastructure, HMRC Platform Team](#friends-don’t-let-friends-build-infrastructure)                                                                                  |                          |                                         |
+| 12:10 - 12:35   | [Beyond AI-Assisted Coding: What Comes Next for Software Engineering?, Dr. Fahad Anwar (ONS)](#beyond-ai-assisted-coding%3A-what-comes-next-for-software-engineering%3F)                               |                          |                                         |
+| 12:35 - 13:00   | [Engineering the Future: Why we need a government engineering academy, David Heath](#engineering-the-future%3A-why-we-need-a-government-engineering-academy)                                           |                          |                                         |
+| 13:00 - 14:00   | Lunch                                                                                                                                                                                                  | Lunch                    |                                         |
+| 14:00 - 15:00   | Unconference afternoon  - Lean coffee 1                                                                                                                                                                |                          | Unconference afternoon  - Lean coffee 2 |
+| 15:00 - 15:15   | Coffee break                                                                                                                                                                                           | Coffee break             |                                         |
+| 15:15 - 15:25   | [Lightning talk 1 - You say waterfall and I say agile, but we can’t call the whole thing off, Christine Horrocks (MHCLG)](#you-say-waterfall-and-i-say-agile%2C-but-we-can’t-call-the-whole-thing-off) |                          |                                         |
+| 15:25 - 15:35   | [Lightning talk 2 - Building the front door to government tech, Lianne Williams (DSIT)](#building-the-front-door-to-government-tech)                                                                   |                          |                                         |
+| 15:35 - 15:45   | [Lightning talk 3 - Building a X-Gov search engine for reusable code and design, Aron Marriottsmith (MoJ)](#building-a-x-gov-search-engine-for-reusable-code-and-design)                               |                          |                                         |
+| 15:45 - 15:55   | [Lightning talk 4 - AI in Engineering, Andy Poole (UKHO)](#ai-in-engineering)                                                                                                                          |                          |                                         |
+| 15:55 - 16:05   | [Lightning talk 5 - Managing Github from the trenches, Shaun Hare (DVSA)](#managing-github-from-the-trenches)                                                                                          |                          |                                         |
+| 16:05 - 16:15   | [Lightning talk 6 - Technical Debt at the speed of AI,  Olukayode Esho (UKSA)](#technical-debt-at-the-speed-of-ai)                                                                                     |                          |                                         |
+| 16:15 - 16:25   | [Lightning talk 7 - The 1% gap in your platform - Managing the Product, Amaal Ali (HMRC)](#the-1%25-gap-in-your-platform---managing-the-product)                                                       |                          |                                         |
+| 16:25 - 16:40   | Panel Q&A                                                                                                                                                                                              |                          |                                         |
+| 16:40 - 17:00   | Closing Session                                                                                                                                                                                        |                          |                                         |
+| 17:00 - onwards | Social                                                                                                                                                                                                 |                          |                                         |
+
+
+#### Talk abstracts
+
+##### Invited talks
+
+###### Friends Don't Let Friends Build Infrastructure
+
+No user story ever started with "As a taxpayer, I'd like a better deployment pipeline". Most delivery teams don't want to become experts in infrastructure, networking, observability and cloud operations, and they shouldn't have to. Discover how HMRC's platform teams provide standardised foundations, golden paths and shared capabilities that help teams build services faster, better and cheaper.
+
+Speaker: Chris Wright and Adam Conder, HMRC
+
+###### Beyond AI-Assisted Coding: What Comes Next for Software Engineering?
+
+Exploring insights and future trends in AI-enabled software engineering.
+
+Speaker: Dr. Fahad Anwar, ONS
+
+###### Engineering the Future: Why we need a government engineering academy
+
+In this talk, I propose a Government Engineering Academy to build capability in deep, practice-based software engineering across the public sector. Moving beyond certification-led training toward a discipline-focused model rooted in Continuous Delivery and empirical learning, this proposal aims to cultivate senior technical leadership, reduce contractor reliance, and systematically raise engineering standards to build on opportunities for more effective digital delivery.
+
+Speaker: David Heath, Head of Engineering Enablement, GDS (speaking in an unofficial capacity)
+
+##### Lightning talks
+
+###### You say waterfall and I say agile, but we can’t call the whole thing off 
+
+We have been working with the Scottish Government to integrate their EPB register with the one for the rest of the UK. Between our two teams we have very different ways of approaching project management, work organisation and tracking. We have had to work together, adapting our approaches to accommodate each other. This talk will go through how we have been able to manage differences and pit falls so that in the end everything was fine!
+
+Speaker: Christine Horrocks, MHCLG
+
+###### Building the front door to government tech
+
+Office of the Chief Technology Officer (OCTO), a directorate in Government Digital Service, leads and supports several communities of practice for engineers, architects, and IT operations professionals across the public sector, but joining one often relies on word-of-mouth, and signposting to guidance isn't always clear. This talk explores our research into a new service bringing together technical guidance, tools, and best practice alongside our communities of practice. Drawing on user research with community members about what they value and feel is missing, we will share what's working well today, where the gaps are, and how a more joined-up approach could make it easier for practitioners to find guidance, connect with peers, and grow professionally.
+
+Speaker: Lianne Williams and Sarah Handyside, DSIT
+
+###### Building a X-Gov search engine for reusable code and design
+
+Don't you just hate it when you can't find ""the thing""? A code snippet, a UI component, a tool - it’s nowhere to be found. Someone, somewhere across government, must have faced the same problem and created a solution already. But where do you even look? The Reuse Library solves these problems by enabling you to find existing solutions to reuse. So you can focus on real innovation and delivering value for users.
+The Reuse Library spans across teams, professions, and government departments. What began as a simple community-driven directory has evolved as we've innovated with search and explorations in AI. Here's what we built, what we learnt, and how you can get involved and use it today.
+
+Speaker: Aron Marriott-Smith, MOJ
+
+###### AI in Engineering
+
+How UKHO have deployed AI into our ways of working in Engineering.
+
+Speaker: Andy Poole, UKHO
+
+###### Managing GitHub from the trenches 
+
+A talk about managing GitHub for the department - from the perspective of trying to follow best practice and keep abreast of many teams and deal with the whole lifecycle of a migration to GitHub.
+
+Speaker: Shaun Hare, DVSA
+
+###### Technical Debt at the speed of AI 
+
+AI coding assistants can generate code faster than ever before.  They could help us build better software faster or simply accelerate the creation of technical debt at an alarming speed.  This lightning talk explores how AI tools can accelerate the delivery of features while also introducing poorly understood code, inconsistent patterns, and hidden maintenance challenges. Through real-world examples and lessons learned, we'll examine why the ability to generate code rapidly must be balanced with engineering judgement, code ownership, and long-term maintainability. The talk concludes with practical ways teams can harness AI responsibly without leaving future developers to pay the price.
+
+Speaker: Olukayode Esho, UKHSA
+
+###### The 1% gap in your platform - Managing the Product
+
+Most platform teams have solved the technical side of scaling - CI/CD, observability, unified auth - but the operational problems of running a digital service, like piloting features to a private beta or safely rolling out change via A/B testing, are often left for each product team to solve alone, again and again. This talk looks at how HMRC tackled this gap, building a shared approach that teams could adopt rather than reinvent, and shares what we learned along the way and where we're taking it next.
+
+Speaker: Amaal Ali, HMRC
+
+## Contact us
+
+Please contact us if you need any further information, either using the Cross Government Slack (in the [#govdev26-north channel](https://ukgovernmentdigital.slack.com/archives/C0BR5DPNRC5)) or by emailing the organising committee at [govdev-north@uk-x-gov-software-community.org.uk]([govdev-north@uk-x-gov-software-community.org.uk](mailto:govdev-north@uk-x-gov-software-community.org.uk)) 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "vitest": "^4.1.0"
   },
   "scripts": {
+    "dev": "npx @11ty/eleventy --serve",
     "test": "vitest run",
     "lint": "eslint assets/newsletter-submit.js tests/",
     "build": "eleventy",


### PR DESCRIPTION
This change adds a page for GovDev North 2026.

It also includes a small change adding a new script to `package.json` for convenience of running the 11ty dev server.